### PR TITLE
fix: base href and favicon setting

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -30,7 +30,7 @@
             "tsConfig": "projects/cosmoscan-extension/tsconfig.app.json",
             "aot": true,
             "assets": [
-              "projects/cosmoscan-extension/src/favicon.png",
+              "projects/cosmoscan-extension/src/favicon.ico",
               "projects/cosmoscan-extension/src/assets"
             ],
             "styles": [

--- a/projects/cosmoscan-extension/src/index.html
+++ b/projects/cosmoscan-extension/src/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <title>CosmoscanExtension</title>
-  <base href="/botany/" />
+  <base href="/" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="icon" type="image/x-icon" href="favicon.ico" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">


### PR DESCRIPTION
close #74 

@KimuraYu45z 

index.htmlのbase hrefにbotanyが設定されていたのと、favicon.icoのパスがangular.jsonでfavicon.pngとなっていた点を修正しました。この2点の修正で、ローカルで ng serve してもエラーが出なくなりました。いったんこれでビルド通るか進めてみようと思うのですが問題ないでしょうか？お手数ですがレビューお願いします。