### PR TITLE
feat: faucet

### DIFF
--- a/projects/faucet/jpyx/deploy.sh
+++ b/projects/faucet/jpyx/deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker cp $(docker ps -qf "name=jpyxd"):/usr/bin/jpyxd ~/jpyx-faucet/jpyxd
+docker-compose up -d

--- a/projects/faucet/jpyx/docker-compose.yml
+++ b/projects/faucet/jpyx/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+  jpyx-faucet:
+    container_name: jpyx-faucet
+    image: ghcr.io/tendermint/faucet
+    volumes:
+      - ~/jpyx-faucet/jpyxd:/usr/local/bin/jpyxd
+    # Reference: https://github.com/tendermint/faucet
+    # Todo: Command is not completed. Need to setup faucet account on the node and add the account in the command option.
+    command: faucet --cli-name jpyxd --denoms jpyx,ujsmn,ubtc
+    network_mode: host
+    restart: always

--- a/projects/faucet/jpyx/docker-compose.yml
+++ b/projects/faucet/jpyx/docker-compose.yml
@@ -6,8 +6,7 @@ services:
     image: ghcr.io/tendermint/faucet
     volumes:
       - ~/jpyx-faucet/jpyxd:/usr/local/bin/jpyxd
-    # Reference: https://github.com/tendermint/faucet
-    # Todo: Command is not completed. Need to setup faucet account on the node and add the account in the command option.
-    command: faucet --cli-name jpyxd --denoms jpyx,ujsmn,ubtc
+      - ~/.jpyx:/root/.jpyx
+    command: faucet --cli-name jpyxd --denoms jpyx,ujsmn,ubtc --keyring-backend test --account-name faucet
     network_mode: host
     restart: always


### PR DESCRIPTION
@KimuraYu45z

なかなか着手できていなかったFaucetの作業に手をつけてみました。

参考情報: https://github.com/tendermint/faucet

http://d.test.jpyx.lcnem.net のノード上で以下のように実行することで、

```sh
cd ~/jpyx-faucet
sh deploy.sh
```

フロントから以下のようにAPIを叩くことで、トークンをFaucetから取得できるようになるような意図のプルリクです。

```sh
curl -X POST -d '{"address": "jpyx10lcj22kzftvnduchatmnsnhfljeky5ghd398wt", "coins": ["10ujsmn"]}' http://localhost:8000
```

ただし、現時点では、faucetの起動コマンドで、keyring-passwordやaccountを適切に指定していないため、`{"transfers":[{"coin":"10ujsmn","status":"error","error":"account does not exit"}]}`のようなエラーになっています。

faucetのCLIコマンドを実行する際に、適切なkeyring-passwordを指定したり、faucet用のアカウントをCLIのオプションとして指定する等が追加で必要で、おそらくそれをやれば、動くようになるのかなと思っているのですが、方向性違和感ないか、質問させてもらいたく、いったん途中の状態でプルリクにしてみました。

別途、faucetのフロントのページの実装は必要なように見えたので、それは別途botanyの中のtelescope-extensionの中でページを追加する必要があると思っています。

dのテストネットノード上に、いったん仮で、このプルリクのファイルを配置してあるので、必要あれば、ご参照ください。