### PR TITLE
feat: jpyx telescope home select tx type with pull down

### DIFF
--- a/projects/telescope-extension/editions/jpyx/config.js
+++ b/projects/telescope-extension/editions/jpyx/config.js
@@ -17,6 +17,18 @@ const config = {
         link: '/jpyx',
       }
     ],
-    messageActions: ['']
+    messageActions: [''],
+    messageModules: [
+      'bank', // hit
+      'auth',
+      'crisis',
+      'distribution',
+      'evidence',
+      'genaccounts',
+      'gov',
+      'ibc',
+      'slashing',
+      'staking', // hit
+    ],
   }
 };


### PR DESCRIPTION
@KimuraYu45z 
デプロイ時に使用されるconfig.jsは、botanyレポジトリの中にあり、デプロイ時にそこからダウンロードしているので、LatestTxsの種類をプルダウンで選ぶ件、telescope側の修正だけでなく、botany側の修正が必要であることが漏れており、以下のように、プルダウンリストに表示されるオプションが存在しない状態になっていました。

![image](https://user-images.githubusercontent.com/55148923/134108588-aae1368d-b3a7-484d-8fff-0c65d0e9cca3.png)

取り急ぎ修正したので、レビューお願いします。

@taro04 
状況、ご承知おきください。