### PR TITLE
feat: faucet backend cors reverse proxy and faucet link

### DIFF
--- a/projects/faucet/jpyx/deploy.sh
+++ b/projects/faucet/jpyx/deploy.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 docker-compose down
 curl -O https://raw.githubusercontent.com/lcnem/botany/main/projects/faucet/jpyx/docker-compose.yml
+curl -O https://raw.githubusercontent.com/lcnem/botany/main/projects/faucet/jpyx/nginx.conf
 docker cp $(docker ps -qf "name=jpyxd"):/usr/bin/jpyxd ~/jpyx-faucet/jpyxd
 docker-compose up -d

--- a/projects/faucet/jpyx/docker-compose.yml
+++ b/projects/faucet/jpyx/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: '3'
 
 services:
   jpyx-faucet:
@@ -7,6 +7,12 @@ services:
     volumes:
       - ~/jpyx-faucet/jpyxd:/usr/local/bin/jpyxd
       - ~/.jpyx:/root/.jpyx
-    command: faucet --cli-name jpyxd --denoms jpyx,ujsmn,ubtc --keyring-backend test --account-name faucet
+    command: faucet --cli-name jpyxd --denoms jpyx,ujsmn,ubtc --keyring-backend test --account-name faucet --port 7000 --credit-amount=10 --max-credit=100
+    network_mode: host
+    restart: always
+  nginx:
+    image: nginx
+    volumes:
+      - ~/jpyx-faucet/nginx.conf:/etc/nginx/nginx.conf
     network_mode: host
     restart: always

--- a/projects/faucet/jpyx/nginx.conf
+++ b/projects/faucet/jpyx/nginx.conf
@@ -1,0 +1,30 @@
+events {
+}
+
+http {
+  server {
+    listen 8000;
+    server_name localhost;
+    charset UTF-8;
+
+    location / {
+      proxy_http_version 1.1;
+      proxy_pass http://localhost:7000;
+
+      if ($request_method = 'OPTIONS') {
+        add_header Access-Control-Allow-Origin '*';
+        add_header Access-Control-Allow-Methods 'GET, POST, PUT, DELETE';
+        add_header Access-Control-Allow-Headers 'Origin, Authorization, Accept, Content-Type';
+        # add_header Access-Control-Max-Age 3600;
+        add_header Content-Type 'text/plain charset=UTF-8';
+        add_header Content-Length 0;
+        return 204;
+      }
+
+      add_header Access-Control-Allow-Origin '*';
+      add_header Access-Control-Allow-Methods 'POST, GET, OPTIONS';
+      add_header Access-Control-Allow-Headers 'Origin, Authorization, Accept, Content-Type';
+      add_header Access-Control-Allow-Credentials true;
+    }
+  }
+}

--- a/projects/telescope-extension/src/app/app.component.ts
+++ b/projects/telescope-extension/src/app/app.component.ts
@@ -11,5 +11,11 @@ export class AppComponent {
 
   constructor(private readonly configS: ConfigService) {
     this.config = this.configS.config;
+    if (this.config.extension?.faucet !== undefined) {
+      this.config.extension.navigations.push({
+        name: 'Faucet',
+        link: '/jpyx/faucet'
+      });
+    }
   }
 }


### PR DESCRIPTION
@KimuraYu45z 
レビューお願いします。

リバースプロキシと、CLIで起動したFaucetがOPTIONSリクエストを処理してくれないのでnginx側で処理する処理を書きました。
これをaのテストネットノードで動作させ、前後で対象アドレスの残高が確かにリクエストかけただけ増えていることを確認済です。
以下URLでubtcで1回あたり10ubtc, 1アカウント総計100ubtcまでClaimできる状態になっているので、必要に応じてご確認ください。
ただし、Faucetの残高は少な目なので、たくさん回す場合は、あらかじめFaucetに残高補充して頂けると助かります。
http://a.test.jpyx.lcnem.net/jpyx/faucet

それ以外のノードは、このプルリクマージされ次第、デプロイ用スクリプトを使ってFaucet動作させるつもりで、まだ外部からAPIたたけない状態になっていると思います。

また、フロントへの実装として、config.jsのfaucetフラグが有効な値を持っているなら、Faucetのリンクを表示するような実装を追加しました。

最終的にFaucetの残課題としては以下の問題が未解決ですが、本当に最低限、とりあえず動く状態にはなったかなという状況です。
残課題は別プルリクで修正対応したいと思っています。

- POSTリクエストはバックエンドに通って、確かに残高に反映されるが、POSTリクエストに対するレスポンスが結局フロントエンド側から取得できていない。→リクエスト前に残高をキープしておき、リクエスト後に残高が増えていることを確認して、成功可否判定してスナックバー等の通知を実装する必要がありそう。

@taro04 
状況ご承知おきください。