### PR TITLE
fix: botany navigation path and config

### DIFF
--- a/projects/telescope-extension/editions/jpyx/config.js
+++ b/projects/telescope-extension/editions/jpyx/config.js
@@ -25,7 +25,11 @@ const config = {
     navigations: [
       {
         name: 'JPYX',
-        link: '/jpyx',
+        link: '/jpyx/',
+      },
+      {
+        name: 'Faucet',
+        link: '/jpyx/faucet'
       }
     ],
     messageActions: [''],

--- a/projects/telescope-extension/src/app/app.component.ts
+++ b/projects/telescope-extension/src/app/app.component.ts
@@ -11,11 +11,16 @@ export class AppComponent {
 
   constructor(private readonly configS: ConfigService) {
     this.config = this.configS.config;
+    const prefix = this.config.bech32Prefix?.accAddr;
     if (this.config.extension?.faucet !== undefined) {
-      this.config.extension.navigations.push({
-        name: 'Faucet',
-        link: '/jpyx/faucet'
-      });
+      if (prefix !== undefined) {
+        if (this.config.extension.navigations !== undefined && this.config.extension.navigations.length > 0) {
+          this.config.extension.navigations = this.config.extension.navigations.map((navigation) => ({
+              name: navigation.name,
+              link: navigation.link.replace(`/${prefix}`, '')
+            }));
+        }
+      }
     }
   }
 }

--- a/projects/telescope-extension/src/view/app.component.html
+++ b/projects/telescope-extension/src/view/app.component.html
@@ -20,7 +20,7 @@
 
       <ng-template ngFor let-extension [ngForOf]="extensionNavigations">
         <ng-container *ngIf="extension?.name && extension?.link">
-          <mat-list-item routerLink="/">
+          <mat-list-item routerLink="{{ extension?.link }}">
             {{ extension.name }}
           </mat-list-item>
         </ng-container>


### PR DESCRIPTION
close #95 

@KimuraYu45z 
レビューお願いします。

Faucetのリンクの問題の修正とともに、付随するリンク関連の問題の修正を試みるプルリクです。
ローカルではFaucetのリンク、JPYXのホームページともに意図通り動くことを確認しました。
telescope側でもこの設定ファイルの修正でJPYXのホームページをはじめとする拡張ページのリンクを適切に表示＆適切に動作可能な状態になったと思います。

マージ後、デプロイして動作確認し、FaucetのリンクやJPYXのリンクが機能していれば、リンクの問題は解決となる認識です。