### PR TITLE
fix: add monitorURL

### DIFF
--- a/projects/telescope-extension/editions/jpyx/config.js
+++ b/projects/telescope-extension/editions/jpyx/config.js
@@ -39,6 +39,11 @@ const config = {
       'ibc',
       'slashing',
       'staking', // hit
+      'auction',
+      'botanydist',
+      'cdp',
+      'incentive',
+      'pricefeed',
     ],
   },
 };

--- a/projects/telescope-extension/editions/jpyx/config.js
+++ b/projects/telescope-extension/editions/jpyx/config.js
@@ -14,13 +14,12 @@ const config = {
     faucet: {
       hasFaucet: true,
       faucetURL: `${location.protocol}//${location.hostname}:8000`,
-      denoms: [
-        'ujsmn',
-        'ubtc',
-        'jpyx',
-      ],
+      denoms: ['ujsmn', 'ubtc', 'jpyx'],
       creditAmount: 10, // amount to credit in each request
       maxCredit: 100, // maximum credit per account
+    },
+    monitor: {
+      monitorURL: `${location.protocol}//localhost:9000`,
     },
     navigations: [
       {
@@ -41,5 +40,5 @@ const config = {
       'slashing',
       'staking', // hit
     ],
-  }
+  },
 };


### PR DESCRIPTION
telescopeのMonitor機能を使うための修正です。

- monitorURLを`config.js`に追加

次回のデプロイまでにマージしてもらえれば大丈夫です。