### PR TITLE
fix: cdp gas collateral type with work around way

### DIFF
--- a/projects/telescope-extension/src/app/models/cdps/cdp.infrastructure.service.ts
+++ b/projects/telescope-extension/src/app/models/cdps/cdp.infrastructure.service.ts
@@ -41,12 +41,13 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
       return;
     }
 
+    // Todo: collateral_type should be set more appropriately.
     // build tx
     const msgCreateCdp = new botany.cdp.MsgCreateCdp({
       sender: sender.toString(),
       collateral,
       principal,
-      collateral_type: collateral.denom,
+      collateral_type: collateral.denom + '-a',
     });
 
     const txBody = new proto.cosmos.tx.v1beta1.TxBody({
@@ -65,7 +66,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
         },
       ],
       fee: {
-        gas_limit: cosmosclient.Long.fromString('200000'),
+        gas_limit: cosmosclient.Long.fromString('300000'),
       },
     });
 
@@ -102,10 +103,11 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
       return;
     }
 
+    // Todo: collateral_type should be set more appropriately.
     // build tx
     const msgDrawdebtCdp = new botany.cdp.MsgDrawDebt({
       sender: sender.toString(),
-      collateral_type: denom,
+      collateral_type: denom + '-a',
       principal,
     });
 
@@ -125,7 +127,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
         },
       ],
       fee: {
-        gas_limit: cosmosclient.Long.fromString('200000'),
+        gas_limit: cosmosclient.Long.fromString('300000'),
       },
     });
 
@@ -162,10 +164,11 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
       return;
     }
 
+    // Todo: collateral_type should be set more appropriately.
     // build tx
     const msgDrawdebtCdp = new botany.cdp.MsgRepayDebt({
       sender: sender.toString(),
-      collateral_type: denom,
+      collateral_type: denom + '-a',
       payment,
     });
 
@@ -185,7 +188,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
         },
       ],
       fee: {
-        gas_limit: cosmosclient.Long.fromString('200000'),
+        gas_limit: cosmosclient.Long.fromString('300000'),
       },
     });
 
@@ -222,12 +225,13 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
       return;
     }
 
+    // Todo: collateral_type should be set more appropriately.
     // build tx
     const msgDrawdebtCdp = new botany.cdp.MsgDeposit({
       depositor: sender.toString(),
       owner: ownerAddr.toString(),
       collateral,
-      collateral_type: collateral.denom,
+      collateral_type: collateral.denom + '-a',
     });
 
     const txBody = new proto.cosmos.tx.v1beta1.TxBody({
@@ -246,7 +250,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
         },
       ],
       fee: {
-        gas_limit: cosmosclient.Long.fromString('200000'),
+        gas_limit: cosmosclient.Long.fromString('300000'),
       },
     });
 
@@ -283,12 +287,13 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
       return;
     }
 
+    // Todo: collateral_type should be set more appropriately.
     // build tx
     const msgDrawdebtCdp = new botany.cdp.MsgWithdraw({
       depositor: sender.toString(),
       owner: ownerAddr.toString(),
       collateral,
-      collateral_type: collateral.denom,
+      collateral_type: collateral.denom + '-a',
     });
 
     const txBody = new proto.cosmos.tx.v1beta1.TxBody({
@@ -307,7 +312,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
         },
       ],
       fee: {
-        gas_limit: cosmosclient.Long.fromString('200000'),
+        gas_limit: cosmosclient.Long.fromString('300000'),
       },
     });
 


### PR DESCRIPTION
@KimuraYu45z cc: @Senna46 @taro04 
レビューお願いします。
この修正を加えた状態で、ローカルで動作させたtelescope側でcdp createできることを確認しました。

以下リンクのトランザクションです。
http://a.test.jpyx.lcnem.net/txs/C64D5C218DB5F6D550FD96B7F6D34D0411827DE55F0B3C406026FEA9BC736AE9

修正内容は以下の通りです。特にcollateral_typeについてはその場しのぎ的な修正になっていますが、いったんこれをデプロイしてデバッグ進めたいと思っています。

- ガス代が最大20万ujsmnでは足りていなかったので、最大30万ujsmnに変更
- collateral_typeとしてubtc-aを指定すべきだがubtcがセットされていたので、直接書き換える形で変更 <- これは本来はcdp params等からフォームにも適切に表示して、フォームから値を取得して、createCDP関数の引数として各サービス間で引き回す形等検討すべきながしていますが、その修正は別途やろうと思います。