### PR TITLE
[WIP] fix: cdp collateral type and denom

### DIFF
--- a/projects/telescope-extension/src/app/models/cdps/cdp.application.service.ts
+++ b/projects/telescope-extension/src/app/models/cdps/cdp.application.service.ts
@@ -124,6 +124,17 @@ export class CdpApplicationService {
   ) {
     const dialogRef = this.loadingDialog.open('Sending');
 
+    console.log(
+      'key',
+      key,
+      'privateKey',
+      privateKey,
+      'ownerAddr',
+      ownerAddr,
+      'collateral',
+      collateral,
+    );
+
     let txhash: string | undefined;
     try {
       const res: any = await this.cdp.depositCDP(key, privateKey, ownerAddr, collateral);
@@ -146,8 +157,9 @@ export class CdpApplicationService {
       duration: 6000,
     });
 
-    const redirectUrl = `${location.protocol}//${location.hostname}/txs/${txhash}`;
-    window.location.href = redirectUrl;
+    /* Disable for Debug */
+    // const redirectUrl = `${location.protocol}//${location.hostname}/txs/${txhash}`;
+    // window.location.href = redirectUrl;
   }
 
   async withdrawCDP(

--- a/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/cdp.component.html
+++ b/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/cdp.component.html
@@ -1,5 +1,6 @@
 <view-cdp
   [owner]="owner$ | async"
+  [collateralType]="collateralType$ | async"
   [denom]="denom$ | async"
   [params]="params$ | async"
   [cdp]="cdp$ | async"

--- a/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/cdp.component.ts
+++ b/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/cdp.component.ts
@@ -16,6 +16,7 @@ import { map, mergeMap } from 'rxjs/operators';
 })
 export class CdpComponent implements OnInit {
   owner$: Observable<string>;
+  collateralType$: Observable<string>;
   denom$: Observable<string>;
   params$: Observable<botany.cdp.IParams>;
   cdp$: Observable<InlineResponse2004Cdp1>;
@@ -31,34 +32,53 @@ export class CdpComponent implements OnInit {
     private readonly cosmosSdk: CosmosSDKService,
   ) {
     this.owner$ = this.route.params.pipe(map((params) => params['owner']));
-    this.denom$ = this.route.params.pipe(map((params) => params['denom']));
-    const ownerAndDenom$ = combineLatest([this.owner$, this.denom$, this.cosmosSdk.sdk$]);
-
+    this.collateralType$ = this.route.params.pipe(map((params) => params['collateralType']));
     this.params$ = this.cosmosSdk.sdk$.pipe(
       mergeMap((sdk) => rest.botany.cdp.params(sdk.rest)),
       map((data) => data.data.params!),
     );
+    this.denom$ = combineLatest([this.collateralType$, this.params$]).pipe(
+      map(([collateralType, params]) => {
+        const matchedDenoms = params.collateral_params?.filter(
+          (param) => param.type === collateralType,
+        );
+        return matchedDenoms ? (matchedDenoms[0].denom ? matchedDenoms[0].denom : '') : '';
+      }),
+    );
+    const ownerAndCollateralType$ = combineLatest([
+      this.owner$,
+      this.collateralType$,
+      this.cosmosSdk.sdk$,
+    ]);
 
-    this.cdp$ = ownerAndDenom$.pipe(
-      mergeMap(([ownerAddr, denom, sdk]) =>
-        rest.botany.cdp.cdp(sdk.rest, cosmosclient.AccAddress.fromString(ownerAddr), denom),
+    this.cdp$ = ownerAndCollateralType$.pipe(
+      mergeMap(([ownerAddr, collateralType, sdk]) =>
+        rest.botany.cdp.cdp(
+          sdk.rest,
+          cosmosclient.AccAddress.fromString(ownerAddr),
+          collateralType,
+        ),
       ),
       map((res) => res.data.cdp!),
     );
 
-    this.deposits$ = ownerAndDenom$.pipe(
-      mergeMap(([ownerAddr, denom, sdk]) =>
-        rest.botany.cdp.allDeposits(sdk.rest, cosmosclient.AccAddress.fromString(ownerAddr), denom),
+    this.deposits$ = ownerAndCollateralType$.pipe(
+      mergeMap(([ownerAddr, collateralType, sdk]) =>
+        rest.botany.cdp.allDeposits(
+          sdk.rest,
+          cosmosclient.AccAddress.fromString(ownerAddr),
+          collateralType,
+        ),
       ),
       map((res) => res.data.deposits || []),
     );
 
     this.spotPrice$ = this.cosmosSdk.sdk$.pipe(
-      mergeMap((sdk) => getSpotPriceStream(sdk.rest, this.denom$, this.params$)),
+      mergeMap((sdk) => getSpotPriceStream(sdk.rest, this.collateralType$, this.params$)),
     );
 
     this.liquidationPrice$ = this.cosmosSdk.sdk$.pipe(
-      mergeMap((sdk) => getLiquidationPriceStream(sdk.rest, this.denom$, this.params$)),
+      mergeMap((sdk) => getLiquidationPriceStream(sdk.rest, this.collateralType$, this.params$)),
     );
 
     this.withdrawLimit$ = zip(this.cdp$, this.params$, this.spotPrice$).pipe(

--- a/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/cdp.component.ts
+++ b/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/cdp.component.ts
@@ -6,7 +6,7 @@ import { rest, botany } from 'botany-client';
 import { InlineResponse2004Cdp1, InlineResponse2006Deposits } from 'botany-client/esm/openapi';
 import { cosmosclient } from 'cosmos-client';
 import { CosmosSDKService } from 'projects/telescope-extension/src/app/models/index';
-import { combineLatest, from, Observable, pipe, zip } from 'rxjs';
+import { combineLatest, Observable, zip } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
 @Component({
@@ -64,13 +64,14 @@ export class CdpComponent implements OnInit {
 
     this.deposits$ = ownerAndCollateralType$.pipe(
       mergeMap(([ownerAddr, collateralType, sdk]) =>
-        rest.botany.cdp.allDeposits(
-          sdk.rest,
-          cosmosclient.AccAddress.fromString(ownerAddr),
-          collateralType,
-        ),
+        rest.botany.cdp
+          .allDeposits(sdk.rest, cosmosclient.AccAddress.fromString(ownerAddr), collateralType)
+          .catch((error) => {
+            console.error(error);
+            return undefined;
+          }),
       ),
-      map((res) => res.data.deposits || []),
+      map((res) => res?.data.deposits || []),
     );
 
     this.spotPrice$ = this.cosmosSdk.sdk$.pipe(

--- a/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/clear/clear.component.html
+++ b/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/clear/clear.component.html
@@ -1,6 +1,7 @@
 <view-clear
   [key]="key$ | async"
   [owner]="owner$ | async"
+  [collateralType]="collateralType$ | async"
   [denom]="denom$ | async"
   [paymentDenom]="paymentDenom$ | async"
   (appSubmit)="onSubmit($event)"

--- a/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/clear/clear.component.ts
+++ b/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/clear/clear.component.ts
@@ -1,15 +1,15 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { rest } from 'botany-client';
+import { botany } from 'projects/botany-client/dist/cjs';
 import {
   CdpApplicationService,
   CosmosSDKService,
-  KeyService,
 } from 'projects/telescope-extension/src/app/models/index';
 import { Key } from 'projects/telescope-extension/src/app/models/keys/key.model';
 import { KeyStoreService } from 'projects/telescope-extension/src/app/models/keys/key.store.service';
 import { ClearCdpOnSubmitEvent } from 'projects/telescope-extension/src/app/views/cdp/cdps/cdp/clear/clear.component';
-import { Observable } from 'rxjs';
+import { combineLatest, Observable } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
 @Component({
@@ -20,6 +20,8 @@ import { map, mergeMap } from 'rxjs/operators';
 export class ClearComponent implements OnInit {
   key$: Observable<Key | undefined>;
   owner$: Observable<string>;
+  collateralType$: Observable<string>;
+  params$: Observable<botany.cdp.IParams>;
   denom$: Observable<string>;
   paymentDenom$: Observable<string>;
 
@@ -31,20 +33,34 @@ export class ClearComponent implements OnInit {
   ) {
     this.key$ = this.keyStore.currentKey$.asObservable();
     this.owner$ = this.route.params.pipe(map((params) => params['owner']));
-    this.denom$ = this.route.params.pipe(map((params) => params['denom']));
+    this.collateralType$ = this.route.params.pipe(map((params) => params['collateralType']));
+    this.params$ = this.cosmosSdk.sdk$.pipe(
+      mergeMap((sdk) => rest.botany.cdp.params(sdk.rest)),
+      map((data) => data.data.params!),
+    );
+    this.denom$ = combineLatest([this.collateralType$, this.params$]).pipe(
+      map(([collateralType, params]) => {
+        const matchedDenoms = params.collateral_params?.filter(
+          (param) => param.type === collateralType,
+        );
+        return matchedDenoms ? (matchedDenoms[0].denom ? matchedDenoms[0].denom : '') : '';
+      }),
+    );
     this.paymentDenom$ = this.cosmosSdk.sdk$.pipe(
       mergeMap((sdk) => rest.botany.cdp.params(sdk.rest)),
       map((param) => param.data.params?.debt_param?.denom || ''),
     );
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.collateralType$.subscribe((collateralType) => console.log(collateralType));
+  }
 
   onSubmit($event: ClearCdpOnSubmitEvent) {
     this.cdpApplicationService.repayCDP(
       $event.key,
       $event.privateKey,
-      $event.denom,
+      $event.collateralType,
       $event.payment,
     );
   }

--- a/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/deposit/deposit.component.html
+++ b/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/deposit/deposit.component.html
@@ -1,6 +1,7 @@
 <view-deposit
   [key]="key$ | async"
   [owner]="owner$ | async"
+  [collateralType]="collateralType$ | async"
   [denom]="denom$ | async"
   (appSubmit)="onSubmit($event)"
 ></view-deposit>

--- a/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/deposit/deposit.component.ts
+++ b/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/deposit/deposit.component.ts
@@ -1,11 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { rest, botany } from 'botany-client';
+import { CosmosSDKService } from 'projects/telescope-extension/src/app/models/index';
 import { CdpApplicationService } from 'projects/telescope-extension/src/app/models/index';
 import { Key } from 'projects/telescope-extension/src/app/models/keys/key.model';
 import { KeyStoreService } from 'projects/telescope-extension/src/app/models/keys/key.store.service';
 import { DepositCdpOnSubmitEvent } from 'projects/telescope-extension/src/app/views/cdp/cdps/cdp/deposit/deposit.component';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { combineLatest, Observable } from 'rxjs';
+import { map, mergeMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-deposit',
@@ -15,16 +17,31 @@ import { map } from 'rxjs/operators';
 export class DepositComponent implements OnInit {
   key$: Observable<Key | undefined>;
   owner$: Observable<string>;
+  collateralType$: Observable<string>;
+  params$: Observable<botany.cdp.IParams>;
   denom$: Observable<string>;
 
   constructor(
     private readonly route: ActivatedRoute,
+    private readonly cosmosSDK: CosmosSDKService,
     private readonly keyStore: KeyStoreService,
     private readonly cdpApplicationService: CdpApplicationService,
   ) {
     this.key$ = this.keyStore.currentKey$.asObservable();
     this.owner$ = this.route.params.pipe(map((params) => params['owner']));
-    this.denom$ = this.route.params.pipe(map((params) => params['denom']));
+    this.collateralType$ = this.route.params.pipe(map((params) => params['collateralType']));
+    this.params$ = this.cosmosSDK.sdk$.pipe(
+      mergeMap((sdk) => rest.botany.cdp.params(sdk.rest)),
+      map((data) => data.data.params!),
+    );
+    this.denom$ = combineLatest([this.collateralType$, this.params$]).pipe(
+      map(([collateralType, params]) => {
+        const matchedDenoms = params.collateral_params?.filter(
+          (param) => param.type === collateralType,
+        );
+        return matchedDenoms ? (matchedDenoms[0].denom ? matchedDenoms[0].denom : '') : '';
+      }),
+    );
   }
 
   ngOnInit(): void {}

--- a/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/issue/issue.component.html
+++ b/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/issue/issue.component.html
@@ -1,6 +1,7 @@
 <view-issue
   [key]="key$ | async"
   [owner]="owner$ | async"
+  [collateralType]="collateralType$ | async"
   [denom]="denom$ | async"
   [principalDenom]="principalDenom$ | async"
   (appSubmit)="onSubmit($event)"

--- a/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/withdraw/withdraw.component.html
+++ b/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/withdraw/withdraw.component.html
@@ -1,6 +1,7 @@
 <view-withdraw
   [key]="key$ | async"
   [owner]="owner$ | async"
+  [collateralType]="collateralType$ | async"
   [denom]="denom$ | async"
   (appSubmit)="onSubmit($event)"
 ></view-withdraw>

--- a/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/withdraw/withdraw.component.ts
+++ b/projects/telescope-extension/src/app/pages/cdp/cdps/cdp/withdraw/withdraw.component.ts
@@ -1,11 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { rest, botany } from 'botany-client';
+import { CosmosSDKService } from 'projects/telescope-extension/src/app/models/index';
 import { CdpApplicationService } from 'projects/telescope-extension/src/app/models/index';
 import { Key } from 'projects/telescope-extension/src/app/models/keys/key.model';
 import { KeyStoreService } from 'projects/telescope-extension/src/app/models/keys/key.store.service';
 import { WithdrawCdpOnSubmitEvent } from 'projects/telescope-extension/src/app/views/cdp/cdps/cdp/withdraw/withdraw.component';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { combineLatest, Observable } from 'rxjs';
+import { mergeMap, map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-withdraw',
@@ -15,16 +17,31 @@ import { map } from 'rxjs/operators';
 export class WithdrawComponent implements OnInit {
   key$: Observable<Key | undefined>;
   owner$: Observable<string>;
+  collateralType$: Observable<string>;
+  params$: Observable<botany.cdp.IParams>;
   denom$: Observable<string>;
 
   constructor(
     private readonly route: ActivatedRoute,
+    private readonly cosmosSdk: CosmosSDKService,
     private readonly keyStore: KeyStoreService,
     private readonly cdpApplicationService: CdpApplicationService,
   ) {
     this.key$ = this.keyStore.currentKey$.asObservable();
     this.owner$ = this.route.params.pipe(map((params) => params['owner']));
-    this.denom$ = this.route.params.pipe(map((params) => params['denom']));
+    this.collateralType$ = this.route.params.pipe(map((params) => params['collateralType']));
+    this.params$ = this.cosmosSdk.sdk$.pipe(
+      mergeMap((sdk) => rest.botany.cdp.params(sdk.rest)),
+      map((data) => data.data.params!),
+    );
+    this.denom$ = combineLatest([this.collateralType$, this.params$]).pipe(
+      map(([collateralType, params]) => {
+        const matchedDenoms = params.collateral_params?.filter(
+          (param) => param.type === collateralType,
+        );
+        return matchedDenoms ? (matchedDenoms[0].denom ? matchedDenoms[0].denom : '') : '';
+      }),
+    );
   }
 
   ngOnInit(): void {}

--- a/projects/telescope-extension/src/app/pages/cdp/cdps/cdps-routing.module.ts
+++ b/projects/telescope-extension/src/app/pages/cdp/cdps/cdps-routing.module.ts
@@ -18,23 +18,23 @@ const routes: Routes = [
     component: CreateComponent,
   },
   {
-    path: ':owner/:denom',
+    path: ':owner/:collateralType',
     component: CdpComponent,
   },
   {
-    path: ':owner/:denom/deposit',
+    path: ':owner/:collateralType/deposit',
     component: DepositComponent,
   },
   {
-    path: ':owner/:denom/withdraw',
+    path: ':owner/:collateralType/withdraw',
     component: WithdrawComponent,
   },
   {
-    path: ':owner/:denom/issue',
+    path: ':owner/:collateralType/issue',
     component: IssueComponent,
   },
   {
-    path: ':owner/:denom/clear',
+    path: ':owner/:collateralType/clear',
     component: ClearComponent,
   },
 ];

--- a/projects/telescope-extension/src/app/views/cdp/cdps/cdp/cdp.component.html
+++ b/projects/telescope-extension/src/app/views/cdp/cdps/cdp/cdp.component.html
@@ -35,14 +35,14 @@
         <span class="column-value">
           <a
             mat-stroked-button
-            href="cdp/cdps/{{ owner }}/{{ denom }}/deposit"
+            href="cdp/cdps/{{ owner }}/{{ collateralType }}/deposit"
             target="_blank"
             >Deposit</a
           >
           <a
             class="withdraw-button"
             mat-stroked-button
-            href="cdp/cdps/{{ owner }}/{{ denom }}/withdraw"
+            href="cdp/cdps/{{ owner }}/{{ collateralType }}/withdraw"
             target="_blank"
             >Withdraw</a
           >
@@ -69,7 +69,7 @@
         <span class="column-value">
           <a
             mat-stroked-button
-            href="cdp/cdps/{{ owner }}/{{ denom }}/issue"
+            href="cdp/cdps/{{ owner }}/{{ collateralType }}/issue"
             target="_blank"
           >
             Issue
@@ -77,7 +77,7 @@
           <a
             class="clear-button"
             mat-stroked-button
-            href="cdp/cdps/{{ owner }}/{{ denom }}/clear"
+            href="cdp/cdps/{{ owner }}/{{ collateralType }}/clear"
             target="_blank"
           >
             Clear

--- a/projects/telescope-extension/src/app/views/cdp/cdps/cdp/cdp.component.ts
+++ b/projects/telescope-extension/src/app/views/cdp/cdps/cdp/cdp.component.ts
@@ -12,6 +12,9 @@ export class CdpComponent implements OnInit {
   owner?: string | null;
 
   @Input()
+  collateralType?: string | null;
+
+  @Input()
   denom?: string | null;
 
   @Input()
@@ -35,13 +38,20 @@ export class CdpComponent implements OnInit {
   @Input()
   issueLimit?: number | null;
 
-  constructor() { }
+  constructor() {}
 
   ngOnInit(): void {
     setTimeout(() => {
-      console.log('params', this.params);
-      console.log('cdp', this.cdp);
-      console.log('deposits', this.deposits);
+      console.log(this.owner);
+      console.log(this.collateralType);
+      console.log(this.denom);
+      console.log(this.params);
+      console.log(this.cdp);
+      console.log(this.deposits);
+      console.log(this.spotPrice);
+      console.log(this.liquidationPrice);
+      console.log(this.withdrawLimit);
+      console.log(this.issueLimit);
     }, 10000);
   }
 }

--- a/projects/telescope-extension/src/app/views/cdp/cdps/cdp/clear/clear.component.html
+++ b/projects/telescope-extension/src/app/views/cdp/cdps/cdp/clear/clear.component.html
@@ -5,14 +5,14 @@
     onSubmit(
       privateKeyRef.value,
       ownerRef.value,
-      collateralDenomRef.value,
+      collateralTypeRef.value,
       paymentDenomRef.value,
       paymentAmountRef.value
     )
   ">
   <mat-form-field class="w-full">
-    <mat-label>Collateral Denom</mat-label>
-    <input #collateralDenomRef [(ngModel)]="denom" name="collateral-denom" matInput readonly required />
+    <mat-label>Collateral Type</mat-label>
+    <input #collateralTypeRef [(ngModel)]="collateralType" name="collateral-type" matInput readonly required />
   </mat-form-field>
   <div>
     <mat-form-field class="w-full">

--- a/projects/telescope-extension/src/app/views/cdp/cdps/cdp/clear/clear.component.ts
+++ b/projects/telescope-extension/src/app/views/cdp/cdps/cdp/clear/clear.component.ts
@@ -6,7 +6,7 @@ export type ClearCdpOnSubmitEvent = {
   key: Key;
   privateKey: string;
   ownerAddr: cosmosclient.AccAddress;
-  denom: string;
+  collateralType: string;
   payment: proto.cosmos.base.v1beta1.ICoin;
 };
 
@@ -21,6 +21,9 @@ export class ClearComponent implements OnInit {
 
   @Input()
   owner?: string | null;
+
+  @Input()
+  collateralType?: string | null;
 
   @Input()
   denom?: string | null;
@@ -43,7 +46,7 @@ export class ClearComponent implements OnInit {
   onSubmit(
     privateKey: string,
     ownerAddr: string,
-    collateralDenom: string,
+    collateralType: string,
     paymentDenom: string,
     paymentAmount: string,
   ) {
@@ -51,7 +54,7 @@ export class ClearComponent implements OnInit {
       key: this.key!,
       privateKey,
       ownerAddr: cosmosclient.AccAddress.fromString(ownerAddr),
-      denom: collateralDenom,
+      collateralType: collateralType,
       payment: {
         denom: paymentDenom,
         amount: paymentAmount,

--- a/projects/telescope-extension/src/app/views/cdp/cdps/cdp/deposit/deposit.component.html
+++ b/projects/telescope-extension/src/app/views/cdp/cdps/cdp/deposit/deposit.component.html
@@ -11,6 +11,10 @@
   ">
   <div>
     <mat-form-field class="w-full">
+      <mat-label>Collateral Type</mat-label>
+      <input #collateralTypeRef [(ngModel)]="collateralType" name="collateral-type" matInput readonly />
+    </mat-form-field>
+    <mat-form-field class="w-full">
       <mat-label>Collateral Denom</mat-label>
       <input #collateralDenomRef [(ngModel)]="denom" name="collateral-denom" matInput readonly />
     </mat-form-field>

--- a/projects/telescope-extension/src/app/views/cdp/cdps/cdp/deposit/deposit.component.ts
+++ b/projects/telescope-extension/src/app/views/cdp/cdps/cdp/deposit/deposit.component.ts
@@ -22,6 +22,9 @@ export class DepositComponent implements OnInit {
   owner?: string | null;
 
   @Input()
+  collateralType?: string | null;
+
+  @Input()
   denom?: string | null;
 
   @Output()

--- a/projects/telescope-extension/src/app/views/cdp/cdps/cdp/issue/issue.component.html
+++ b/projects/telescope-extension/src/app/views/cdp/cdps/cdp/issue/issue.component.html
@@ -5,14 +5,14 @@
     onSubmit(
       privateKeyRef.value,
       ownerRef.value,
-      collateralDenomRef.value,
+      collateralTypeRef.value,
       principalDenomRef.value,
       principalAmountRef.value
     )
   ">
   <mat-form-field class="w-full">
-    <mat-label>Collateral Denom</mat-label>
-    <input #collateralDenomRef [(ngModel)]="denom" name="collateral-denom" matInput readonly required />
+    <mat-label>Collateral Type</mat-label>
+    <input #collateralTypeRef [(ngModel)]="collateralType" name="collateral-type" matInput readonly required />
   </mat-form-field>
   <div>
     <mat-form-field class="w-full">

--- a/projects/telescope-extension/src/app/views/cdp/cdps/cdp/issue/issue.component.ts
+++ b/projects/telescope-extension/src/app/views/cdp/cdps/cdp/issue/issue.component.ts
@@ -6,7 +6,7 @@ export type IssueCdpOnSubmitEvent = {
   key: Key;
   privateKey: string;
   ownerAddr: cosmosclient.AccAddress;
-  denom: string;
+  collateralType: string;
   principal: proto.cosmos.base.v1beta1.ICoin;
 };
 
@@ -21,6 +21,9 @@ export class IssueComponent implements OnInit {
 
   @Input()
   owner?: string | null;
+
+  @Input()
+  collateralType?: string | null;
 
   @Input()
   denom?: string | null;
@@ -43,7 +46,7 @@ export class IssueComponent implements OnInit {
   onSubmit(
     privateKey: string,
     ownerAddr: string,
-    collateralDenom: string,
+    collateralType: string,
     principalDenom: string,
     principalAmount: string,
   ) {
@@ -51,7 +54,7 @@ export class IssueComponent implements OnInit {
       key: this.key!,
       privateKey,
       ownerAddr: cosmosclient.AccAddress.fromString(ownerAddr),
-      denom: collateralDenom,
+      collateralType: collateralType,
       principal: {
         denom: principalDenom,
         amount: principalAmount,

--- a/projects/telescope-extension/src/app/views/cdp/cdps/cdp/withdraw/withdraw.component.html
+++ b/projects/telescope-extension/src/app/views/cdp/cdps/cdp/withdraw/withdraw.component.html
@@ -11,6 +11,10 @@
   ">
   <div>
     <mat-form-field class="w-full">
+      <mat-label>Collateral Type</mat-label>
+      <input #collateralTypeRef [(ngModel)]="collateralType" name="collateral-type" matInput readonly />
+    </mat-form-field>
+    <mat-form-field class="w-full">
       <mat-label>Collateral Denom</mat-label>
       <input #collateralDenomRef [(ngModel)]="denom" name="collateral-denom" matInput readonly />
     </mat-form-field>

--- a/projects/telescope-extension/src/app/views/cdp/cdps/cdp/withdraw/withdraw.component.ts
+++ b/projects/telescope-extension/src/app/views/cdp/cdps/cdp/withdraw/withdraw.component.ts
@@ -22,6 +22,9 @@ export class WithdrawComponent implements OnInit {
   owner?: string | null;
 
   @Input()
+  collateralType?: string | null;
+
+  @Input()
   denom?: string | null;
 
   @Output()


### PR DESCRIPTION
@KimuraYu45z cc: @Senna46 @taro04 
中途半端な状況ですが、現状をプルリクにして共有しておきます。

collateralType(ubtc-aとかのCDPの種類を表す名前？)とcollateralDenomあるいはdenom(ubtcとかの担保側通貨名)が、表記が入り混じっていて、デバッグする前に、混乱しそうだったので、componentの側を、現状流れているデータにあわせて、改名し、CDPが複数種類あった場合でも矛盾なく対応できるよう、collateralTypeやparamsからcollateralDenomを取得するよう実装を追加しました。

ただ、現時点ではまだdeposit, withdraw, issue, clearいずれも、正常に動作することが確認できていない状態で、デバッグ用にトランザクション完了後のページ遷移を抑制していたり、service側の修正が追加で必要そうに見えていることや、場合によってはjpyx側レポジトリの修正も必要かもと見えていて、現時点ではcomponent側のパラメーター名関連のみ修正したところまでしか進んでいないという状況です。