### PR TITLE
feat: change .ico to .png

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -27,7 +27,7 @@
             "polyfills": "projects/main/src/polyfills.ts",
             "tsConfig": "projects/main/tsconfig.app.json",
             "assets": [
-              "projects/main/src/favicon.ico",
+              "projects/main/src/favicon.png",
               "projects/main/src/assets"
             ],
             "styles": [


### PR DESCRIPTION
Landing PageのOGP画像が表示されていないので設定を再確認。
明らかに間違っているの点を１点修正しました。

その他の設定についてはいくつかサイト確認しましたが、
問題ないように思います。
[https://kaikoku.blam.co.jp/client/digimaguild/knowledge/sns-pr/498#title4](https://kaikoku.blam.co.jp/client/digimaguild/knowledge/sns-pr/498#title4)
[http://ogp.tokyo/basic-metadata/](http://ogp.tokyo/basic-metadata/)
[https://www.itra.co.jp/webmedia/what-is-ogp.html](https://www.itra.co.jp/webmedia/what-is-ogp.html)

設定確認している際に、<head>にprefix="og: http://ogp.me/ns#" が設定されてないことが気になりましたが、
以下キャプチャの通りローカルでのOGP動作確認できたので、問題ないと思っています。
![image](https://user-images.githubusercontent.com/75844498/140515003-bdf753b9-e588-44da-b188-a70a7e3bda56.png)

ただ、OGPの画像自体の表示は、確認できていないです。

chrome拡張機能[OG](https://qiita.com/TeruhisaFukumoto/items/6032efde115a17b45637)と[Card Validator](https://cards-dev.twitter.com/validator)を用いてデバックをしていたのですが、OGP画像はハードコーディングでサーバーの画像を指定しているので、そもそもローカルで確認できるのか？と疑問に思い進捗報告も兼ねＰＲ作成しました。

一旦この変更と、https://botany.lcnem.com/favicon.png に画像があることを確認したうえで、実際のサーバーで確認いただくことは可能でしょうか？