### PR TITLE
fix: hide jpyx faucet and add versioning deploy script

### DIFF
--- a/projects/telescope-extension/editions/jpyx/launch/jpyx-3-test/full/config.js
+++ b/projects/telescope-extension/editions/jpyx/launch/jpyx-3-test/full/config.js
@@ -27,7 +27,7 @@ const config = {
         maxCredit: 1999999,
       },
       {
-        hasFaucet: true,
+        hasFaucet: false,
         faucetURL: `${location.protocol}//${location.hostname}:8004`,
         denom: 'jpyx',
         creditAmount: 10,

--- a/projects/telescope-extension/editions/jpyx/launch/jpyx-3-test/light/config.js
+++ b/projects/telescope-extension/editions/jpyx/launch/jpyx-3-test/light/config.js
@@ -27,7 +27,7 @@ const config = {
         maxCredit: 1999999,
       },
       {
-        hasFaucet: true,
+        hasFaucet: false,
         faucetURL: `${location.protocol}//a.test.jpyx.lcnem.net:8004`,
         denom: 'jpyx',
         creditAmount: 10,

--- a/projects/telescope-extension/editions/jpyx/launch/jpyx-3-test/light/deploy.sh
+++ b/projects/telescope-extension/editions/jpyx/launch/jpyx-3-test/light/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+cd ~/jpyx-telescope
+docker-compose down
+docker pull lcnem/telescope:latest
+docker pull lcnem/telescope-jpyx:latest
+curl -O https://raw.githubusercontent.com/lcnem/botany/main/projects/telescope-extension/editions/jpyx/docker-compose.yml
+curl -O https://raw.githubusercontent.com/lcnem/botany/main/projects/telescope-extension/nginx.conf
+curl -O https://raw.githubusercontent.com/lcnem/botany/main/projects/telescope-extension/editions/jpyx/launch/jpyx-3-test/light/config.js
+docker-compose up -d

--- a/projects/telescope-extension/editions/jpyx/launch/jpyx-3-test/standard/config.js
+++ b/projects/telescope-extension/editions/jpyx/launch/jpyx-3-test/standard/config.js
@@ -27,7 +27,7 @@ const config = {
         maxCredit: 1999999,
       },
       {
-        hasFaucet: true,
+        hasFaucet: false,
         faucetURL: `${location.protocol}//a.test.jpyx.lcnem.net:8004`,
         denom: 'jpyx',
         creditAmount: 10,

--- a/projects/telescope-extension/editions/jpyx/launch/jpyx-3-test/standard/deploy.sh
+++ b/projects/telescope-extension/editions/jpyx/launch/jpyx-3-test/standard/deploy.sh
@@ -5,5 +5,5 @@ docker pull lcnem/telescope:latest
 docker pull lcnem/telescope-jpyx:latest
 curl -O https://raw.githubusercontent.com/lcnem/botany/main/projects/telescope-extension/editions/jpyx/docker-compose.yml
 curl -O https://raw.githubusercontent.com/lcnem/botany/main/projects/telescope-extension/nginx.conf
-curl -O https://raw.githubusercontent.com/lcnem/botany/main/projects/telescope-extension/editions/jpyx/config.js
+curl -O https://raw.githubusercontent.com/lcnem/botany/main/projects/telescope-extension/editions/jpyx/launch/jpyx-3-test/standard/config.js
 docker-compose up -d


### PR DESCRIPTION
@KimuraYu45z 
レビューお願いします。

Faucetについて、jpyx用のFaucetは不要と判断し、config.jsを修正しました。

ubtcとujcbnは必須＆ジェネシスブロックに残高用意しておけば問題なく準備できるものの、jpyxについてはcdpをcreateしてポジションを管理しておく必要が生じ、大量のcdpを作っておくとテスト用のubtcにも無駄が生じるため、改めて考えて不要と考えたという状況です。

一応、実装自体は活かしておいて、非表示にする形にしておき、デバッガーやユーザーが混乱しないよう修正したいと思います。

また、この機会に、configの種類に応じてダウンロード箇所が変わる部分等を考慮し、デプロイスクリプトの環境やバージョン毎のバリエーションも追加しておくことにしました。