### PR TITLE
feat: add gas settings to config

### DIFF
--- a/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/full/config.js
+++ b/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/full/config.js
@@ -10,25 +10,31 @@ const config = {
     consAddr: 'jpyxvalcons',
     consPub: 'jpyxvalconspub',
   },
+  minimumGasPrices: [
+    {
+      denom: 'ujcbn',
+      amount: 0.015,
+    }
+  ],
   extension: {
     faucet: [
       {
         hasFaucet: true,
-        faucetURL: `${location.protocol}//${location.hostname}:8000`,
+        faucetURL: `${location.protocol}//b.test.jpyx.lcnem.net:8000`,
         denom: 'ubtc',
         creditAmount: 100, // amount to credit in max request
         maxCredit: 99, // account has already maxCredit balance cannot claim anymore
       },
       {
         hasFaucet: true,
-        faucetURL: `${location.protocol}//${location.hostname}:8002`,
+        faucetURL: `${location.protocol}//b.test.jpyx.lcnem.net:8002`,
         denom: 'ujcbn',
         creditAmount: 2000000,
         maxCredit: 1999999,
       },
       {
         hasFaucet: false,
-        faucetURL: `${location.protocol}//${location.hostname}:8004`,
+        faucetURL: `${location.protocol}//b.test.jpyx.lcnem.net:8004`,
         denom: 'jpyx',
         creditAmount: 10,
         maxCredit: 9,

--- a/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/light/config.js
+++ b/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/light/config.js
@@ -10,25 +10,31 @@ const config = {
     consAddr: 'jpyxvalcons',
     consPub: 'jpyxvalconspub',
   },
+  minimumGasPrices: [
+    {
+      denom: 'ujcbn',
+      amount: 0.015,
+    }
+  ],
   extension: {
     faucet: [
       {
         hasFaucet: true,
-        faucetURL: `${location.protocol}//a.test.jpyx.lcnem.net:8000`,
+        faucetURL: `${location.protocol}//b.test.jpyx.lcnem.net:8000`,
         denom: 'ubtc',
         creditAmount: 100, // amount to credit in max request
         maxCredit: 99, // account has already maxCredit balance cannot claim anymore
       },
       {
         hasFaucet: true,
-        faucetURL: `${location.protocol}//a.test.jpyx.lcnem.net:8002`,
+        faucetURL: `${location.protocol}//b.test.jpyx.lcnem.net:8002`,
         denom: 'ujcbn',
         creditAmount: 2000000,
         maxCredit: 1999999,
       },
       {
         hasFaucet: false,
-        faucetURL: `${location.protocol}//a.test.jpyx.lcnem.net:8004`,
+        faucetURL: `${location.protocol}//b.test.jpyx.lcnem.net:8004`,
         denom: 'jpyx',
         creditAmount: 10,
         maxCredit: 9,

--- a/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/standard/config.js
+++ b/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/standard/config.js
@@ -10,25 +10,31 @@ const config = {
     consAddr: 'jpyxvalcons',
     consPub: 'jpyxvalconspub',
   },
+  minimumGasPrices: [
+    {
+      denom: 'ujcbn',
+      amount: 0.015,
+    }
+  ],
   extension: {
     faucet: [
       {
         hasFaucet: true,
-        faucetURL: `${location.protocol}//a.test.jpyx.lcnem.net:8000`,
+        faucetURL: `${location.protocol}//b.test.jpyx.lcnem.net:8000`,
         denom: 'ubtc',
         creditAmount: 100, // amount to credit in max request
         maxCredit: 99, // account has already maxCredit balance cannot claim anymore
       },
       {
         hasFaucet: true,
-        faucetURL: `${location.protocol}//a.test.jpyx.lcnem.net:8002`,
+        faucetURL: `${location.protocol}//b.test.jpyx.lcnem.net:8002`,
         denom: 'ujcbn',
         creditAmount: 2000000,
         maxCredit: 1999999,
       },
       {
         hasFaucet: false,
-        faucetURL: `${location.protocol}//a.test.jpyx.lcnem.net:8004`,
+        faucetURL: `${location.protocol}//b.test.jpyx.lcnem.net:8004`,
         denom: 'jpyx',
         creditAmount: 10,
         maxCredit: 9,


### PR DESCRIPTION
@KimuraYu45z 
レビューお願いします。

telescopeのデプロイで、configにminimumGasPricesの設定追加や、テストネットのみ手数料不要なノード固定でFaucetのURLを設定する修正が必要となったため、あらかじめコンフィグだけ修正しておきたいという内容です。(bのノードのみ手数料不要でトランザクション投げられる設定にしておきます。)

- add minimumGasPrices
- change faucet URL to b's node (b's node config is minimumGasPrices="")