### PR TITLE
feat: bumps cosmos client and botany client on pricefeed and simulate

### DIFF
--- a/projects/pricefeed/launch/jpyx-4-test/.env.example
+++ b/projects/pricefeed/launch/jpyx-4-test/.env.example
@@ -1,0 +1,35 @@
+# the chain-id
+CHAIN_ID=jpyx-4-test
+
+# minimum gas price denom
+MINIMUM_GAS_PRICE_DENOM=ujcbn
+
+# minimum gas price amount
+MINIMUM_GAS_PRICE_AMOUNT=0.015
+
+# REST endpoint
+# like http://localhost:1217
+LCD_URL=http://host.docker.internal:1317
+
+# Cron tab for how frequently prices will be posted (ex: 1 hour)
+CRONTAB=0 * * * *
+
+# bip39 mnemonic of oracle
+MNEMONIC=
+
+# List of markets the oracle will post prices for. See pricefeed parameters for the list of active markets.
+MARKET_IDS=ubtc:jpy,ubtc:jpy:30
+
+# percentage deviation from previous price needed to trigger a new price - (example 0.5%)
+DEVIATION=0.005
+
+# how long (in seconds) each price will remain valid - this value should be equal to the amount of time it takes for you to respond to a server outage (example 4 hours )
+EXPIRY=14400
+
+# how long (in seconds) before the oracle will consider a price expiring and post a new price, regardless of the value of deviation.
+# for example, if this is set to 600, the oracle will post a price any time the current posted price is expiring in less than 600 seconds.
+EXPIRY_THRESHOLD=300
+
+BECH32PREFIX=jpyx
+
+OPEN_EXCHANGE_RATES_APP_ID=

--- a/projects/pricefeed/package-lock.json
+++ b/projects/pricefeed/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@cosmos-client/core": "^0.44.3",
+        "@cosmos-client/core": "^0.44.4",
         "axios": "^0.21.1",
         "botany-client": "^0.44.0",
         "ccxt": "^1.57.37",
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@cosmos-client/core": {
-      "version": "0.44.3",
-      "resolved": "https://registry.npmjs.org/@cosmos-client/core/-/core-0.44.3.tgz",
-      "integrity": "sha512-kOf1dGPql9LaVZp99/qdfjs2Fqa5X/vkc6zvbeUJ7Hgvlwrfav8TR5F5Zffh48HC4WTw284Evz6AsefqvST3bw==",
+      "version": "0.44.4",
+      "resolved": "https://registry.npmjs.org/@cosmos-client/core/-/core-0.44.4.tgz",
+      "integrity": "sha512-AkY19ILFRYU4Vakrq5A5heWoRIc5O4zff7dUIyRrT4mH6rlJWr7/8jHLMWC+Q3xIGrKNBWDsk909IXGdL6dqNQ==",
       "dependencies": {
         "axios": "^0.23.0",
         "bech32": "^1.1.4",
@@ -1994,9 +1994,9 @@
   },
   "dependencies": {
     "@cosmos-client/core": {
-      "version": "0.44.3",
-      "resolved": "https://registry.npmjs.org/@cosmos-client/core/-/core-0.44.3.tgz",
-      "integrity": "sha512-kOf1dGPql9LaVZp99/qdfjs2Fqa5X/vkc6zvbeUJ7Hgvlwrfav8TR5F5Zffh48HC4WTw284Evz6AsefqvST3bw==",
+      "version": "0.44.4",
+      "resolved": "https://registry.npmjs.org/@cosmos-client/core/-/core-0.44.4.tgz",
+      "integrity": "sha512-AkY19ILFRYU4Vakrq5A5heWoRIc5O4zff7dUIyRrT4mH6rlJWr7/8jHLMWC+Q3xIGrKNBWDsk909IXGdL6dqNQ==",
       "requires": {
         "axios": "^0.23.0",
         "bech32": "^1.1.4",

--- a/projects/pricefeed/package-lock.json
+++ b/projects/pricefeed/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
+        "@cosmos-client/core": "^0.44.3",
         "axios": "^0.21.1",
-        "botany-client": "^0.6.0",
+        "botany-client": "^0.44.0",
         "ccxt": "^1.57.37",
-        "cosmos-client": "^0.42.14",
         "dotenv": "^8.2.0",
         "log-timestamp": "^0.3.0",
         "node-cron": "^2.0.3",
@@ -24,6 +24,29 @@
         "@types/node": "^14.6.0",
         "@types/node-cron": "^2.0.3",
         "nodemon": "^2.0.4"
+      }
+    },
+    "node_modules/@cosmos-client/core": {
+      "version": "0.44.3",
+      "resolved": "https://registry.npmjs.org/@cosmos-client/core/-/core-0.44.3.tgz",
+      "integrity": "sha512-kOf1dGPql9LaVZp99/qdfjs2Fqa5X/vkc6zvbeUJ7Hgvlwrfav8TR5F5Zffh48HC4WTw284Evz6AsefqvST3bw==",
+      "dependencies": {
+        "axios": "^0.23.0",
+        "bech32": "^1.1.4",
+        "bip32": "^2.0.6",
+        "bip39": "^3.0.4",
+        "protobufjs": "^6.11.2",
+        "rxjs": "^7.4.0",
+        "secp256k1": "^4.0.2",
+        "tweetnacl": "^1.0.3"
+      }
+    },
+    "node_modules/@cosmos-client/core/node_modules/axios": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
+      "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -310,9 +333,9 @@
       "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
     },
     "node_modules/bip39": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.3.tgz",
-      "integrity": "sha512-P0dKrz4g0V0BjXfx7d9QNkJ/Txcz/k+hM9TnjqjUaXtuOfAvxXSw2rJw8DX0e3ZPwnK/IgDxoRqf0bvoVCqbMg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.4.tgz",
+      "integrity": "sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==",
       "dependencies": {
         "@types/node": "11.11.6",
         "create-hash": "^1.1.0",
@@ -331,15 +354,15 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/botany-client": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/botany-client/-/botany-client-0.6.0.tgz",
-      "integrity": "sha512-Ee8omYhZ2qQqZ0AP6aiqWoJb/YknO077HeN/zsUGoNqzfkrCr+gsK/Z4LLmKe1FtJHSDa5pil1ai+AyMp/mOsQ==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/botany-client/-/botany-client-0.44.0.tgz",
+      "integrity": "sha512-KmJNxzg5cn1TbwrOdhdQ0OQ01RhS8NHA3XTaATDCKCOSkEvBG/iWYxdLWUTbgrjr7GCwbHFP/M6VsS8zKshiZw==",
       "dependencies": {
         "axios": "^0.21.1",
         "protobufjs": "^6.11.2"
       },
       "peerDependencies": {
-        "cosmos-client": "^0.42.14"
+        "@cosmos-client/core": "^0.44.3"
       }
     },
     "node_modules/boxen": {
@@ -606,21 +629,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cosmos-client": {
-      "version": "0.42.14",
-      "resolved": "https://registry.npmjs.org/cosmos-client/-/cosmos-client-0.42.14.tgz",
-      "integrity": "sha512-vvZu6wh2tOEgiQSrDkFu2D8yA9t1Degpx0pjEjjwIMfXtTR0KOrlNH9lNIPwuQEkjZuJt4OANVySkW/s1e8Y5Q==",
-      "dependencies": {
-        "axios": "^0.21.1",
-        "bech32": "^1.1.3",
-        "bip32": "^2.0.5",
-        "bip39": "^3.0.2",
-        "protobufjs": "^6.11.2",
-        "rxjs": "^6.6.7",
-        "tiny-secp256k1": "^1.1.6",
-        "tweetnacl": "^1.0.1"
-      }
-    },
     "node_modules/create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -772,9 +780,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
-      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
       "funding": [
         {
           "type": "individual",
@@ -1227,6 +1235,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
+    "node_modules/node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
     "node_modules/node-cron": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-2.0.3.tgz",
@@ -1238,6 +1251,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/nodemon": {
@@ -1365,9 +1388,9 @@
       }
     },
     "node_modules/pbkdf2": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
-      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
       "dependencies": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -1544,14 +1567,11 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "~2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -1572,6 +1592,20 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/secp256k1": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "elliptic": "^6.5.2",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "5.7.1",
@@ -1779,9 +1813,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
@@ -1959,6 +1993,31 @@
     }
   },
   "dependencies": {
+    "@cosmos-client/core": {
+      "version": "0.44.3",
+      "resolved": "https://registry.npmjs.org/@cosmos-client/core/-/core-0.44.3.tgz",
+      "integrity": "sha512-kOf1dGPql9LaVZp99/qdfjs2Fqa5X/vkc6zvbeUJ7Hgvlwrfav8TR5F5Zffh48HC4WTw284Evz6AsefqvST3bw==",
+      "requires": {
+        "axios": "^0.23.0",
+        "bech32": "^1.1.4",
+        "bip32": "^2.0.6",
+        "bip39": "^3.0.4",
+        "protobufjs": "^6.11.2",
+        "rxjs": "^7.4.0",
+        "secp256k1": "^4.0.2",
+        "tweetnacl": "^1.0.3"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.23.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
+          "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+          "requires": {
+            "follow-redirects": "^1.14.4"
+          }
+        }
+      }
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2210,9 +2269,9 @@
       }
     },
     "bip39": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.3.tgz",
-      "integrity": "sha512-P0dKrz4g0V0BjXfx7d9QNkJ/Txcz/k+hM9TnjqjUaXtuOfAvxXSw2rJw8DX0e3ZPwnK/IgDxoRqf0bvoVCqbMg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.4.tgz",
+      "integrity": "sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==",
       "requires": {
         "@types/node": "11.11.6",
         "create-hash": "^1.1.0",
@@ -2233,9 +2292,9 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "botany-client": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/botany-client/-/botany-client-0.6.0.tgz",
-      "integrity": "sha512-Ee8omYhZ2qQqZ0AP6aiqWoJb/YknO077HeN/zsUGoNqzfkrCr+gsK/Z4LLmKe1FtJHSDa5pil1ai+AyMp/mOsQ==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/botany-client/-/botany-client-0.44.0.tgz",
+      "integrity": "sha512-KmJNxzg5cn1TbwrOdhdQ0OQ01RhS8NHA3XTaATDCKCOSkEvBG/iWYxdLWUTbgrjr7GCwbHFP/M6VsS8zKshiZw==",
       "requires": {
         "axios": "^0.21.1",
         "protobufjs": "^6.11.2"
@@ -2455,21 +2514,6 @@
         "xdg-basedir": "^4.0.0"
       }
     },
-    "cosmos-client": {
-      "version": "0.42.14",
-      "resolved": "https://registry.npmjs.org/cosmos-client/-/cosmos-client-0.42.14.tgz",
-      "integrity": "sha512-vvZu6wh2tOEgiQSrDkFu2D8yA9t1Degpx0pjEjjwIMfXtTR0KOrlNH9lNIPwuQEkjZuJt4OANVySkW/s1e8Y5Q==",
-      "requires": {
-        "axios": "^0.21.1",
-        "bech32": "^1.1.3",
-        "bip32": "^2.0.5",
-        "bip39": "^3.0.2",
-        "protobufjs": "^6.11.2",
-        "rxjs": "^6.6.7",
-        "tiny-secp256k1": "^1.1.6",
-        "tweetnacl": "^1.0.1"
-      }
-    },
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -2597,9 +2641,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
-      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -2943,6 +2987,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
+    "node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
     "node-cron": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-2.0.3.tgz",
@@ -2951,6 +3000,11 @@
         "opencollective-postinstall": "^2.0.0",
         "tz-offset": "0.0.1"
       }
+    },
+    "node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
     },
     "nodemon": {
       "version": "2.0.7",
@@ -3049,9 +3103,9 @@
       }
     },
     "pbkdf2": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
-      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
       "requires": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -3193,17 +3247,27 @@
       }
     },
     "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "~2.1.0"
       }
     },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "secp256k1": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "requires": {
+        "elliptic": "^6.5.2",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      }
     },
     "semver": {
       "version": "5.7.1",
@@ -3355,9 +3419,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "tweetnacl": {
       "version": "1.0.3",

--- a/projects/pricefeed/package.json
+++ b/projects/pricefeed/package.json
@@ -23,7 +23,7 @@
     "axios": "^0.21.1",
     "botany-client": "^0.44.0",
     "ccxt": "^1.57.37",
-    "@cosmos-client/core": "^0.44.3",
+    "@cosmos-client/core": "^0.44.4",
     "dotenv": "^8.2.0",
     "log-timestamp": "^0.3.0",
     "node-cron": "^2.0.3",

--- a/projects/pricefeed/package.json
+++ b/projects/pricefeed/package.json
@@ -21,9 +21,9 @@
   "homepage": "https://github.com/lcnem/pricefeed#readme",
   "dependencies": {
     "axios": "^0.21.1",
-    "botany-client": "^0.6.0",
+    "botany-client": "^0.44.0",
     "ccxt": "^1.57.37",
-    "cosmos-client": "^0.42.14",
+    "@cosmos-client/core": "^0.44.3",
     "dotenv": "^8.2.0",
     "log-timestamp": "^0.3.0",
     "node-cron": "^2.0.3",

--- a/projects/pricefeed/src/price-oracle.ts
+++ b/projects/pricefeed/src/price-oracle.ts
@@ -313,6 +313,80 @@ export class PriceOracle {
     const txBody = new proto.cosmos.tx.v1beta1.TxBody({
       messages: [cosmosclient.codec.packAny(msgPostPrice)],
     });
+
+    // auth info for simulation
+    const simulatedAuthInfo = new proto.cosmos.tx.v1beta1.AuthInfo({
+      signer_infos: [
+        {
+          public_key: cosmosclient.codec.packAny(privKey.pubKey()),
+          mode_info: {
+            single: {
+              mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
+            },
+          },
+          sequence: sequence,
+        },
+      ],
+      fee: {
+        amount: [
+          {
+            denom: process.env.MINIMUM_GAS_PRICE_DENOM,
+            amount: '1',
+          },
+        ],
+        gas_limit: cosmosclient.Long.fromString('1'),
+      },
+    });
+
+    const simulatedTxBuilder = new cosmosclient.TxBuilder(this.sdk, txBody, simulatedAuthInfo);
+    const simulatedSignDocBytes = simulatedTxBuilder.signDocBytes(account.account_number);
+    simulatedTxBuilder.addSignature(privKey.sign(simulatedSignDocBytes));
+    const txForSimulation = JSON.parse(simulatedTxBuilder.cosmosJSONStringify());
+    delete txForSimulation.auth_info.signer_infos[0].mode_info.multi;
+
+    let simulatedResult;
+    let gas: proto.cosmos.base.v1beta1.ICoin;
+    let fee: proto.cosmos.base.v1beta1.ICoin;
+
+    // simulate
+    try {
+      simulatedResult = await rest.tx.simulate(this.sdk, {
+        tx: txForSimulation,
+        tx_bytes: simulatedTxBuilder.txBytes(),
+      });
+      console.log('simulate');
+      console.log(simulatedResult);
+      const simulatedGasUsed = simulatedResult.data.gas_info?.gas_used;
+      const simulatedGasUsedWithMarginNumber = simulatedGasUsed
+        ? parseInt(simulatedGasUsed) * 1.1
+        : 200000;
+      const simulatedGasUsedWithMargin = simulatedGasUsedWithMarginNumber.toFixed(0);
+      const simulatedFeeWithMarginNumber =
+        parseInt(simulatedGasUsedWithMargin) *
+        parseFloat(
+          process.env.MINIMUM_GAS_PRICE_AMOUNT ? process.env.MINIMUM_GAS_PRICE_AMOUNT : '200000',
+        );
+      const simulatedFeeWithMargin = simulatedFeeWithMarginNumber.toFixed(0);
+      console.log({
+        simulatedGasUsed,
+        simulatedGasUsedWithMargin,
+        simulatedFeeWithMarginNumber,
+        simulatedFeeWithMargin,
+      });
+      gas = {
+        denom: process.env.MINIMUM_GAS_PRICE_DENOM,
+        amount: simulatedGasUsedWithMargin,
+      };
+      fee = {
+        denom: process.env.MINIMUM_GAS_PRICE_DENOM,
+        amount: simulatedFeeWithMargin,
+      };
+    } catch (e) {
+      console.error(e);
+      return;
+    }
+
+    // auth info for announce
     const authInfo = new proto.cosmos.tx.v1beta1.AuthInfo({
       signer_infos: [
         {
@@ -326,7 +400,8 @@ export class PriceOracle {
         },
       ],
       fee: {
-        gas_limit: cosmosclient.Long.fromString('200000'),
+        amount: [fee],
+        gas_limit: cosmosclient.Long.fromString(gas.amount ? gas.amount : '200000'),
       },
     });
 
@@ -341,6 +416,7 @@ export class PriceOracle {
         tx_bytes: txBuilder.txBytes(),
         mode: rest.tx.BroadcastTxMode.Block,
       });
+      console.log('broadcast');
       console.log(res);
     } catch (e) {
       console.error(e);

--- a/projects/pricefeed/src/price-oracle.ts
+++ b/projects/pricefeed/src/price-oracle.ts
@@ -4,8 +4,8 @@ import { FIAT_CURRENCIES } from './constants/currency';
 import { Ticker } from './domain/market-price';
 import { OraclePrice } from './domain/oracle-price';
 import * as utils from './utils';
+import { cosmosclient, rest, proto } from '@cosmos-client/core';
 import { rest as botanyrest, botany } from 'botany-client';
-import { cosmosclient, rest, proto } from 'cosmos-client';
 import Long from 'long';
 
 require('dotenv').config();
@@ -78,7 +78,7 @@ export class PriceOracle {
   async postPrices() {
     const privKey = await this.privKey;
     const address = cosmosclient.AccAddress.fromPublicKey(privKey.pubKey());
-    const account = await rest.cosmos.auth
+    const account = await rest.auth
       .account(this.sdk, address)
       .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account));
 
@@ -337,9 +337,9 @@ export class PriceOracle {
 
     // broadcast
     try {
-      const res = await rest.cosmos.tx.broadcastTx(this.sdk, {
+      const res = await rest.tx.broadcastTx(this.sdk, {
         tx_bytes: txBuilder.txBytes(),
-        mode: rest.cosmos.tx.BroadcastTxMode.Block,
+        mode: rest.tx.BroadcastTxMode.Block,
       });
       console.log(res);
     } catch (e) {


### PR DESCRIPTION
@KimuraYu45z 
レビューお願いします。(ローカルでのデバッグは未実施ですが、これについては、問題なさそうであれば、サーバー上で直接動作させて、デバッグ試そうと思っています。)

pricefeedのcosmos-client, botany-clientのバージョンアップ対応と、simulateの追加による適切な手数料設定の実装です。
simulateの追加は、telescopeレポジトリで実装したときと異なり、pricefeedの中では対応すべきトランザクションが1種類だけだったので、抽象化は保留にしておきました。もし複数のトランザクションにpricefeedとして対応する必要が今後出たら、抽象化はその時に検討しようと思っています。